### PR TITLE
Using correct category name

### DIFF
--- a/bootstrap-tools.json
+++ b/bootstrap-tools.json
@@ -1490,7 +1490,7 @@
     "VisualStudioOptions": [
         {
             "Category": "TextEditor",
-            "SubCategory": "C/C++ Specific",
+            "SubCategory": "C/C++",
             "Properties": [
                 {
                     "Name": "ClangFormatExePath",


### PR DESCRIPTION
Using C/C++ only instead of "C/C++ Specific" as latest VS does not have "C/C++ Specific" but it has "C/C++" only. 