### PR TITLE
Functionality for UseTWSpecificGitignore which allows us to exempt repos with UseTWSpecificGitignore set to false in the gitignore file check

### DIFF
--- a/bootstrap-repo.json
+++ b/bootstrap-repo.json
@@ -643,7 +643,8 @@
             "TWRepoType": "TWSecondary",
             "Category": "TWShared",
             "RemoteUrl": "https://dev.azure.com/TallySolutions/TWShared/_git/TWScratchPadApps",
-            "LocalPath": "TallySolutions\\TWShared\\TWScratchPadApps"
+            "LocalPath": "TallySolutions\\TWShared\\TWScratchPadApps",
+            "UseTWSpecificGitignore": false
         },
         {
             "RepoName": "TWProofOfConcept",

--- a/bootstrap-repo.json
+++ b/bootstrap-repo.json
@@ -13,8 +13,7 @@
             "TWRepoType": "TWSources",
             "Category": "BuildSupportPlatform",
             "RemoteUrl": "https://dev.azure.com/TallyWorld/BuildSupportPlatform/_git/TWBuildSupport.Source",
-            "LocalPath": "TallyWorld\\BuildSupportPlatform\\TWBuildSupport.Source",
-            "UseTWSpecificGitignore": false
+            "LocalPath": "TallyWorld\\BuildSupportPlatform\\TWBuildSupport.Source"
         },
         {
             "RepoName": "TWDevSupport.Source",

--- a/bootstrap-repo.json
+++ b/bootstrap-repo.json
@@ -13,7 +13,8 @@
             "TWRepoType": "TWSources",
             "Category": "BuildSupportPlatform",
             "RemoteUrl": "https://dev.azure.com/TallyWorld/BuildSupportPlatform/_git/TWBuildSupport.Source",
-            "LocalPath": "TallyWorld\\BuildSupportPlatform\\TWBuildSupport.Source"
+            "LocalPath": "TallyWorld\\BuildSupportPlatform\\TWBuildSupport.Source",
+            "UseTWSpecificGitignore": false
         },
         {
             "RepoName": "TWDevSupport.Source",
@@ -642,7 +643,8 @@
             "TWRepoType": "TWSecondary",
             "Category": "TWShared",
             "RemoteUrl": "https://dev.azure.com/TallySolutions/TWShared/_git/TWScratchPadApps",
-            "LocalPath": "TallySolutions\\TWShared\\TWScratchPadApps"
+            "LocalPath": "TallySolutions\\TWShared\\TWScratchPadApps",
+            "UseTWSpecificGitignore": false
         },
         {
             "RepoName": "TWProofOfConcept",

--- a/bootstrap-repo.json
+++ b/bootstrap-repo.json
@@ -642,8 +642,7 @@
             "TWRepoType": "TWSecondary",
             "Category": "TWShared",
             "RemoteUrl": "https://dev.azure.com/TallySolutions/TWShared/_git/TWScratchPadApps",
-            "LocalPath": "TallySolutions\\TWShared\\TWScratchPadApps",
-            "UseTWSpecificGitignore": false
+            "LocalPath": "TallySolutions\\TWShared\\TWScratchPadApps"
         },
         {
             "RepoName": "TWProofOfConcept",

--- a/bootstrap-repo.json
+++ b/bootstrap-repo.json
@@ -635,7 +635,8 @@
             "TWRepoType": "TWSecondary",
             "Category": "TWShared",
             "RemoteUrl": "https://dev.azure.com/TallySolutions/TWShared/_git/TWSampleProducts",
-            "LocalPath": "TallySolutions\\TWShared\\TWSampleProducts"
+            "LocalPath": "TallySolutions\\TWShared\\TWSampleProducts",
+            "UseTWSpecificGitignore": false
         },
         {
             "RepoName": "TWScratchPadApps",

--- a/bootstrap-repo.json
+++ b/bootstrap-repo.json
@@ -643,8 +643,7 @@
             "TWRepoType": "TWSecondary",
             "Category": "TWShared",
             "RemoteUrl": "https://dev.azure.com/TallySolutions/TWShared/_git/TWScratchPadApps",
-            "LocalPath": "TallySolutions\\TWShared\\TWScratchPadApps",
-            "UseTWSpecificGitignore": false
+            "LocalPath": "TallySolutions\\TWShared\\TWScratchPadApps"
         },
         {
             "RepoName": "TWProofOfConcept",

--- a/bootstrap-repo.json
+++ b/bootstrap-repo.json
@@ -635,8 +635,7 @@
             "TWRepoType": "TWSecondary",
             "Category": "TWShared",
             "RemoteUrl": "https://dev.azure.com/TallySolutions/TWShared/_git/TWSampleProducts",
-            "LocalPath": "TallySolutions\\TWShared\\TWSampleProducts",
-            "UseTWSpecificGitignore": false
+            "LocalPath": "TallySolutions\\TWShared\\TWSampleProducts"
         },
         {
             "RepoName": "TWScratchPadApps",
@@ -651,7 +650,8 @@
             "TWRepoType": "TWSecondary",
             "Category": "TWShared",
             "RemoteUrl": "https://dev.azure.com/TallySolutions/TWShared/_git/TWProofOfConcept",
-            "LocalPath": "TallySolutions\\TWShared\\TWProofOfConcept"
+            "LocalPath": "TallySolutions\\TWShared\\TWProofOfConcept",
+            "UseTWSpecificGitignore": false
         },
 
 

--- a/bootstrap-repo.json
+++ b/bootstrap-repo.json
@@ -642,7 +642,8 @@
             "TWRepoType": "TWSecondary",
             "Category": "TWShared",
             "RemoteUrl": "https://dev.azure.com/TallySolutions/TWShared/_git/TWScratchPadApps",
-            "LocalPath": "TallySolutions\\TWShared\\TWScratchPadApps"
+            "LocalPath": "TallySolutions\\TWShared\\TWScratchPadApps",
+            "UseTWSpecificGitignore": false
         },
         {
             "RepoName": "TWProofOfConcept",


### PR DESCRIPTION
- Added UseTWSpecificGitignore on TWScratchPadApps and TWProofOfConcept repos.